### PR TITLE
bug fix - shouldnt show first user in table when editing others

### DIFF
--- a/src/app/users/[edit]/page.tsx
+++ b/src/app/users/[edit]/page.tsx
@@ -28,8 +28,12 @@ export default function UserPage({params} : { params: {name: string}}) {
             setEditedUser(undefined);
         }
     }
-
-    useEffect(() => { userRepo.findFirst({name: params.name}).then(setUser) }, [params.name]);
+    
+    useEffect(() => { 
+        setUser(undefined);
+        setEditedUser(undefined);
+        userRepo.findFirst({name: params.name}).then(setUser);
+    }, [params.name]);    
 
     if (!user) return <div className='flex font-bold text-2xl items-center justify-center h-96 max-w-'><div>Loading...</div></div>;
 


### PR DESCRIPTION
When editing a specific user from the table, no matter which user is clicked it always would display the first user in the table. This bug fix should fix that. 